### PR TITLE
Support trimming string and array properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,72 @@ If you would like to delete a property off of an object, then set the `$unset` o
     account.merge({}, { $unset: [ 'ssn' ] });
 
 
+#### Trimming strings and arrays of strings
+
+Modinha supports automatically trimming strings or arrays of strings as the data is initialized. This feature is configured on the schema using the `trim` property:
+
+    var Account = Modinha.define({
+      name: {
+        type: 'string',
+        trim: true
+      },
+      contributions: {
+        type: 'array',
+        trim: true
+      }
+    })
+
+    var account = new Account({
+      name: '  Stephen Hawking  ',
+      contributions: [
+        'theories  ',
+        '  understanding the fabric of the universe',
+        ' ice bucket challenge survivor '
+      ]
+    })
+
+    // account.name = 'Stephen Hawking'
+    // account.contributions = [
+    //   'theories',
+    //   'understanding the fabric of the universe',
+    //   'ice bucket challenge survivor'
+    // ]
+
+String trimming can also be limited to only the leading or trailing whitespace by setting `trim` to an object with the `leading` and `trailing` boolean properties:
+
+    var Account = Modinha.define({
+      name: {
+        type: 'string',
+        trim: {
+          leading: true
+        }
+      },
+      contributions: {
+        type: 'array',
+        trim: {
+          trailing: true
+        }
+      }
+    })
+
+    var account = new Account({
+      name: '  Alan Turing  ',
+      contributions: [
+        'cracking the enigma code  ',
+        '  theory of computation',
+        ' the turing test '
+      ]
+    })
+
+    // account.name = 'Alan Turing  '
+    // account.contributions = [
+    //   'cracking the enigma code',
+    //   '  theory of computation',
+    //   ' the turing test'
+    // ]
+
+
+
 #### Serialization and deserialization
 
 By default, Modinha models serialize and deserialize JSON. These methods can be overridden to store data in a different format. For example, we might want to use [MessagePack](http://msgpack.org/) or [CSV](https://tools.ietf.org/html/rfc4180), or perhaps compress the data with [snappy](https://code.google.com/p/snappy/).

--- a/lib/initialize.js
+++ b/lib/initialize.js
@@ -91,6 +91,36 @@ function assign (key, descriptor, source, target, options) {
 
     }
 
+    // trim string values if requested
+    if (descriptor.trim) {
+      var trimLeading = descriptor.trim === true || descriptor.trim.leading
+      var trimTrailing = descriptor.trim === true || descriptor.trim.trailing
+
+      if (descriptor.type === 'string' && typeof target[key] === 'string') {
+
+        if (trimLeading) {
+          target[key] = target[key].replace(/^\s+/, '')
+        }
+        if (trimTrailing) {
+          target[key] = target[key].replace(/\s+$/, '')
+        }
+
+      } else if (descriptor.type === 'array' && Array.isArray(target[key])) {
+
+        for (var i = 0; i < target[key].length; i++) {
+          if (typeof target[key][i] === 'string') {
+            if (trimLeading) {
+              target[key][i] = target[key][i].replace(/^\s+/, '')
+            }
+            if (trimTrailing) {
+              target[key][i] = target[key][i].replace(/\s+$/, '')
+            }
+          }
+        }
+
+      }
+    }
+
     // delete property if explicitly undefined
     if (Array.isArray(options.$unset) &&
       options.$unset.indexOf(key) !== -1) {

--- a/test/InitializeSpec.coffee
+++ b/test/InitializeSpec.coffee
@@ -130,6 +130,92 @@ describe 'assign', ->
     assign('after', descriptors.after, source, target, options)
     target.setAfter.should.equal 'after assignment'
 
+  describe 'trim property', ->
+
+    describe 'with strings', ->
+
+      dsc =
+        trimBothSides:
+          type: 'string'
+          trim: true
+        trimLeading:
+          type: 'string'
+          trim:
+            leading: true
+        trimTrailing:
+          type: 'string'
+          trim:
+            trailing: true
+        noTrim:
+          type: 'string'
+
+      src =
+        trimBothSides: ' test '
+        trimLeading: ' test '
+        trimTrailing: ' test '
+        noTrim: ' test '
+
+      tgt = {}
+
+      it 'should trim both leading and trailing whitespace', ->
+        assign('trimBothSides', dsc.trimBothSides, src, tgt, {})
+        expect(tgt.trimBothSides).to.equal 'test'
+
+      it 'should trim leading whitespace alone', ->
+        assign('trimLeading', dsc.trimLeading, src, tgt, {})
+        expect(tgt.trimLeading).to.equal 'test '
+
+      it 'should trim trailing whitespace alone', ->
+        assign('trimTrailing', dsc.trimTrailing, src, tgt, {})
+        expect(tgt.trimTrailing).to.equal ' test'
+
+      it 'should not trim whitespace if not requested', ->
+        assign('noTrim', dsc.noTrim, src, tgt, {})
+        expect(tgt.noTrim).to.equal ' test '
+
+
+    describe 'arrays', ->
+
+      dsc =
+        trimBothSides:
+          type: 'array'
+          trim: true
+        trimLeading:
+          type: 'array'
+          trim:
+            leading: true
+        trimTrailing:
+          type: 'array'
+          trim:
+            trailing: true
+        noTrim:
+          type: 'array'
+
+      src =
+        trimBothSides: [ ' test0 ', ' test1 ' ]
+        trimLeading: [ ' test0 ', ' test1 ' ]
+        trimTrailing: [ ' test0 ', ' test1 ' ]
+        noTrim: [ ' test0 ', ' test1 ' ]
+
+      tgt = {}
+
+      it 'should trim both leading and trailing whitespace', ->
+        assign('trimBothSides', dsc.trimBothSides, src, tgt, {})
+        expect(tgt.trimBothSides).to.eql [ 'test0', 'test1' ]
+
+      it 'should trim leading whitespace alone', ->
+        assign('trimLeading', dsc.trimLeading, src, tgt, {})
+        expect(tgt.trimLeading).to.eql [ 'test0 ', 'test1 ' ]
+
+      it 'should trim trailing whitespace alone', ->
+        assign('trimTrailing', dsc.trimTrailing, src, tgt, {})
+        expect(tgt.trimTrailing).to.eql [ ' test0', ' test1' ]
+
+      it 'should not trim whitespace if not requested', ->
+        assign('noTrim', dsc.noTrim, src, tgt, {})
+        expect(tgt.noTrim).to.eql [ ' test0 ', ' test1 ' ]
+
+
 
 
 describe 'map', ->


### PR DESCRIPTION
Fixes #15

Schema property descriptors now support a `trim` property on string and array-type properties for trimming excess whitespace.

If set to `true`, both leading and trailing whitespace will be removed.

`trim` can also be set to an object with `leading` and `trailing` properties. Setting them to `true` will trim leading and trailing whitespace only, respectively.